### PR TITLE
Explicitly start ntpd via full path

### DIFF
--- a/fix-ntp.sh
+++ b/fix-ntp.sh
@@ -71,7 +71,7 @@ sync_system_and_hwclock() {
 setup_ntpd() {
     log "Configuring and starting ntpd..."
     cp "$NTP_CONF_SRC" "$NTP_CONF_DEST"
-    /sbin/daemon_mgr ntpd start "ntpd -c $NTP_CONF_DEST"
+    /sbin/daemon_mgr ntpd start "/usr/sbin/ntpd -c $NTP_CONF_DEST"
 }
 
 restart_crond() {


### PR DESCRIPTION
## Summary
- update the ntpd startup command in fix-ntp.sh to invoke /usr/sbin/ntpd explicitly when using daemon_mgr
