### PR TITLE
Add root privilege guard to fix-ntp script

### DIFF
--- a/fix-ntp.sh
+++ b/fix-ntp.sh
@@ -81,6 +81,11 @@ restart_crond() {
 }
 
 main() {
+    if [[ $EUID -ne 0 ]]; then
+        log "Error: This script must be run as root. Please rerun as root (e.g., using sudo)." >&2
+        exit 1
+    fi
+
     log "----- Starting QNAP NTP Setup Script -----"
     check_prerequisites
     safely_stop_processes


### PR DESCRIPTION
## Summary
- add a guard at the start of main() to ensure the script is run with root privileges
- log a clear error instructing operators to rerun the script as root when the guard fails
