### PR TITLE
Ensure fix-ntp script requires administrators group membership

### DIFF
--- a/fix-ntp.sh
+++ b/fix-ntp.sh
@@ -81,6 +81,11 @@ restart_crond() {
 }
 
 main() {
+    if ! id -nG 2>/dev/null | tr ' ' '\n' | grep -qx "administrators"; then
+        log "Error: This script requires membership in the 'administrators' group. Please rerun using an account in that group." >&2
+        exit 1
+    fi
+
     log "----- Starting QNAP NTP Setup Script -----"
     check_prerequisites
     safely_stop_processes


### PR DESCRIPTION
## Summary
- replace the root EUID guard with a check for membership in the administrators group
- update the error message to instruct rerunning the script with an administrators-group account
